### PR TITLE
Baudrate geändert / Serial2.print("")

### DIFF
--- a/test_kommunikation/Kommunikation_DueMitDue/Kommunikation_DueMitDue/Kommunikation_DueMitDue.ino
+++ b/test_kommunikation/Kommunikation_DueMitDue/Kommunikation_DueMitDue/Kommunikation_DueMitDue.ino
@@ -1,27 +1,20 @@
 char c = 0;
 void setup() {
- 
-  Serial.begin(250000);
-  Serial1.begin(250000);
-  Serial2.begin(250000);
-
-  Serial2.print("HelloJanOdermatt");
+  Serial.begin(9600);
+  Serial1.begin(9600);
+  Serial2.begin(9600);
 }
-
 
 void loop() {
   String s;
   s = "";
-
   while (Serial1.available() > 0) {
     c = Serial1.read();
     s += c;
-
   }
   if (s.length() > 0) {
-    Serial.println(s);
+    Serial.print(s);
     Serial2.print(s);
   }
-  
-  delay(1000);
+  delay(10);
 }


### PR DESCRIPTION
Baudrate von 250000 auf 9600 geändert, weil es das gesendete nicht sauber angezeit hat. Mit Baudrate 9600 hat die Kommunikation mit Raspbi und DUE funktioniert. Es wurde vom Raspbi gesendet, vom DUE empfangen und wieder zurückgesendet, dann vom Raspbi wieder angezeigt.